### PR TITLE
undefinedの場合空文字列を返すようにした

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,11 @@
+const getValue = (val, defaultVal) => {
+  if (val === void 0) {
+    return defaultVal;
+  } else {
+    return val;
+  }
+};
+
 export const config = {
-  DEV_API_SERVER: process.env.REACT_APP_API_SERVER,
+  DEV_API_SERVER: getValue(process.env.REACT_APP_API_SERVER, ""),
 };


### PR DESCRIPTION
関数名が思いつかなかったのでpythonの`getenv`風にした