### PR TITLE
selectorを使うようにした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17330,6 +17330,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-syntax-highlighter": "^12.2.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "storybook-react-router": "^1.0.8",
     "styled-components": "^5.0.1",
     "tslint": "^6.0.0",

--- a/src/pages/Contests.js
+++ b/src/pages/Contests.js
@@ -2,18 +2,16 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import ContestsTemplate from "../templates/Contests.js";
-import { contestsOperations } from "../state/ducks/contests";
+import { contestsOperations, contestsSelectors } from "../state/ducks/contests";
 
-const ContestsContainer = ({ contests, fetch }) => {
+const ContestsContainer = ({ contests, isfetched, fetch }) => {
   const endpoint = "/contests";
 
   useEffect(() => {
-    // contestsだけではからのhashに見えるので
-    // その中の要素指定しないとundefinedか確認できない
-    if (contests.upcoming === void 0) {
+    if (!isfetched) {
       fetch(endpoint);
     }
-  }, [endpoint, fetch, contests]);
+  }, [endpoint, fetch, isfetched]);
 
   return (
     <ContestsTemplate
@@ -31,10 +29,12 @@ ContestsContainer.propTypes = {
     recent: PropTypes.array,
   }),
   fetch: PropTypes.func,
+  isfetched: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
-  contests: state.contestsState.contests.data,
+  contests: contestsSelectors.contestsSelector(state),
+  isfetched: contestsSelectors.isfetched(state),
 });
 
 const mapDispatchToProps = {

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -2,27 +2,29 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import HomeTemplate from "../templates/Home.js";
-import { contestsOperations } from "../state/ducks/contests";
+import { contestsOperations, contestsSelectors } from "../state/ducks/contests";
 
-const HomeContainer = ({ slideItemList, fetch }) => {
+const HomeContainer = ({ slideItemList, isfetched, fetch }) => {
   const endpoint = "/contests";
 
   useEffect(() => {
-    if (slideItemList === void 0) {
+    if (!isfetched) {
       fetch(endpoint);
     }
-  }, [endpoint, fetch, slideItemList]);
+  }, [endpoint, fetch, isfetched]);
 
   return <HomeTemplate slideItemList={slideItemList} />;
 };
 
 HomeContainer.propTypes = {
-  slideItemList: PropTypes.object,
+  slideItemList: PropTypes.array,
   fetch: PropTypes.func,
+  isfetched: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
-  slideItemList: state.contestsState.contests.data.upcoming,
+  slideItemList: contestsSelectors.upcomingContestsSelector(state),
+  isfetched: contestsSelectors.isfetched(state),
 });
 
 const mapDispatchToProps = {

--- a/src/state/ducks/contests/selectors.js
+++ b/src/state/ducks/contests/selectors.js
@@ -1,0 +1,19 @@
+import { createSelector } from "reselect";
+
+const contestsSelector = state => state.contestsState.contests.data;
+
+const currentContestsSelector = createSelector(contestsSelector, contests => contests.current);
+
+const upcomingContestsSelector = createSelector(contestsSelector, contests => contests.upcoming);
+
+const recentContestsSelector = createSelector(contestsSelector, contests => contests.recent);
+
+const isfetched = createSelector(contestsSelector, contests => contests.upcoming !== void 0);
+
+export default {
+  contestsSelector,
+  currentContestsSelector,
+  upcomingContestsSelector,
+  recentContestsSelector,
+  isfetched,
+};


### PR DESCRIPTION
## 概要
<!--
PRの概要や変更点などをさくっと書く
-->
selectorから値を取得することで, Containerがstateの情報を知らないで良いようにした.

## 対応するIssue
<!--
Fixes: #0
のように書く
-->
Fixes:

## 参考
- https://qiita.com/zaki-yama/items/5258e6f1ae37f63034b9#createselector-%E3%82%92%E4%BD%BF%E3%81%86%E3%81%A8%E4%BD%95%E3%81%8C%E3%81%86%E3%82%8C%E3%81%97%E3%81%84%E3%81%8B
- https://github.com/jthegedus/re-ducks-examples/blob/master/re-ducks-todos/src/state/ducks/todos/operations.js
- https://github.com/reduxjs/reselect