### PR TITLE
fix: ウィンドウサイズによってロゴのサイズがおかしくなるのをwidthの固定により解決した

### DIFF
--- a/src/atoms/TitleLogo.js
+++ b/src/atoms/TitleLogo.js
@@ -4,7 +4,7 @@ import Logo from "../images/daizuLogo.png";
 
 const useStyles = makeStyles(() => ({
   title: {
-    width: "20%",
+    width: "180px",
     //color: "#ffffff",
     border: "0",
   },


### PR DESCRIPTION
## 概要
ロゴのwidthを180pxにした

## 対応するIssue

Fixes: #58 
